### PR TITLE
Fix QR code generation on initial request

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 16
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '16'
+        java-version: '17'
         distribution: 'adopt'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>16</source>
+                    <target>16</target>
                     <release>${java.version}</release>
                     <annotationProcessorPaths>
                         <path>

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <release>${java.version}</release>
                     <annotationProcessorPaths>
                         <path>

--- a/src/main/java/it/auties/whatsapp4j/whatsapp/internal/WhatsappWebSocket.java
+++ b/src/main/java/it/auties/whatsapp4j/whatsapp/internal/WhatsappWebSocket.java
@@ -92,6 +92,10 @@ public class WhatsappWebSocket {
             session(session);
         }
 
+        sendInitialRequest(session);
+    }
+
+    private void sendInitialRequest(Session session) {
         new InitialRequest<InitialResponse>(options, whatsappKeys){}
                 .send(session)
                 .thenAccept(this::handleInitialMessage);
@@ -127,7 +131,7 @@ public class WhatsappWebSocket {
     private void scheduleQrCodeUpdate(InitialResponse response) {
         Validate.isTrue(response.status() != 429, "Out of attempts to scan the QR code", IllegalStateException.class);
         CompletableFuture.delayedExecutor(response.ttl(), TimeUnit.MILLISECONDS)
-                .execute(() -> generateQrCode(response));
+                .execute(() -> sendInitialRequest(session()));
     }
 
     private void solveChallenge(@NonNull TakeOverResponse response) {


### PR DESCRIPTION
In case of initial QR code wasn't scanned withing defined TTL new QR
code has to be generated. For that initial request has to be sent again
to get new ref, otherwise the same QR code will be generated over and
over again and user could not link it in the Whastapp mobile app, as it
fails with QR code outdated error.