### PR TITLE
Fix: sent messages aren't showing on WhatsApp Desktop

### DIFF
--- a/src/main/java/it/auties/whatsapp/api/Whatsapp.java
+++ b/src/main/java/it/auties/whatsapp/api/Whatsapp.java
@@ -583,7 +583,7 @@ public class Whatsapp {
                 .status(MessageStatus.PENDING)
                 .senderJid(jidOrThrowError())
                 .key(key)
-                .message(message.withDeviceInfo(deviceInfo))
+                .message(recipient.toJid().hasServer(JidServer.GROUP) ? message : message.withDeviceInfo(deviceInfo))
                 .timestampSeconds(timestamp)
                 .broadcast(recipient.toJid().hasServer(JidServer.BROADCAST))
                 .build();


### PR DESCRIPTION
Groups messages don't expect deviceListMetadataVersion